### PR TITLE
added whenAll function and (<*) operator 

### DIFF
--- a/Source/FSharp.Api/Actor.fs
+++ b/Source/FSharp.Api/Actor.fs
@@ -24,8 +24,6 @@ module Actor =
          return _response
       }
    
-   let inline (<!) (actorRef : ActorRef) (message : obj) = actorRef.Ask(message) |> Task.map (fun () -> ())
-   let inline (<?) (actorRef : ActorRef) (message : obj) = actorRef.Ask<'TResponse>(message)
-
-   let Empty = null
-   let Response (result : obj) = result
+   let inline (<!) (actorRef:ActorRef) (message:obj) = actorRef.Ask(message) |> Task.map(ignore)
+   let inline (<?) (actorRef:ActorRef) (message:obj) = actorRef.Ask<'TResponse>(message)
+   let inline (<*) (actorRef:ActorRef) (message:obj) = actorRef.Notify(message)

--- a/Source/FSharp.Api/Task.fs
+++ b/Source/FSharp.Api/Task.fs
@@ -11,7 +11,7 @@ type Result<'T> =
    | Error of exn    
    | Successful of 'T
 
-let wait (task : Task<_>) = task.Wait()
+let inline wait (task : Task<_>) = task.Wait()
 
 let run (t: unit -> Task<_>) = 
    try
@@ -54,6 +54,8 @@ let inline returnM a =
    let s = TaskCompletionSource()
    s.SetResult a
    s.Task
+
+let inline whenAll f (tasks : Task<_> seq) = Task.WhenAll(tasks) |> map(f)
 
 /// Sequentially compose two actions, passing any value produced by the first as an argument to the second.
 let inline (>>=) m f = bind f m

--- a/Source/FSharp.FuncActorDemo/Shop.fs
+++ b/Source/FSharp.FuncActorDemo/Shop.fs
@@ -23,7 +23,7 @@ let ShopActor = actor {
       | Sell (account, count) ->
          let amount = count * shop.Price
          do! account <? Withdraw(amount)
-         return { shop with Cash = shop.Cash + amount;
+         return { shop with Cash = shop.Cash + amount
                             Stock = shop.Stock - count }
       
       | Cash  -> context.Reply(shop.Cash)


### PR DESCRIPTION
added whenAll function for Task API in order to achieve flexibility in computation expressions
added (<*) operator which returns unit - it's convenient for "fire and forget" requests.