### PR TITLE
feat: Dispatch extentions to handle private dispatches

### DIFF
--- a/Source/Orleankka.TestKit.Tests/Orleankka.TestKit.Tests.csproj
+++ b/Source/Orleankka.TestKit.Tests/Orleankka.TestKit.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ActorRefMockFixture.cs" />
     <Compile Include="ActorSystemMockFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestingActorWithDefine.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleankka.Core\Orleankka.Core.csproj">

--- a/Source/Orleankka.TestKit.Tests/TestingActorWithDefine.cs
+++ b/Source/Orleankka.TestKit.Tests/TestingActorWithDefine.cs
@@ -1,0 +1,62 @@
+﻿using NUnit.Framework;
+using Orleankka.Meta;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleankka.TestKit
+{
+    [TestFixture]
+    public class TestingActorWithDefine
+    {
+        [TestCase]
+        public async Task Actor_with_define_can_be_unit_tested()
+        {
+            var actor = new TestActor();
+            actor.Define();
+            await actor.OnReceive(new Handled());
+            Assert.IsTrue(actor.Handled);
+        }
+
+        [TestCase]
+        public async Task Actor_can_be_tested_if_OnRecieve_is_overriden()
+        {
+            var actor = new ActorForbiddingEventRecieves();
+            actor.Define();
+            Assert.Throws<InvalidOperationException>(async ()=>
+                await actor.OnReceive(new Handled())
+            );
+            await actor.Dispatch(new Handled());
+            Assert.IsTrue(actor.Handled);
+        }
+    }
+
+
+    public class ActorForbiddingEventRecieves : Actor
+    {
+        protected override Task<object> OnReceive(object message)
+        {
+            if(message is Event)
+                throw new InvalidOperationException("I pretend to be EventSourced and don't accept Events");
+            return Task.FromResult(message);
+        }
+        public bool Handled { get; private set; }
+        protected override void Define()
+        {
+            On<Handled>(ev => Handled = true);
+        }
+    }
+
+    public class TestActor : Actor {
+
+        public bool Handled { get; private set; }
+        protected override void Define()
+        {
+            On<Handled>(ev => Handled = true);
+        }
+    }
+
+    public class Handled:Event{}
+}

--- a/Source/Orleankka.TestKit/ActorExtensions.cs
+++ b/Source/Orleankka.TestKit/ActorExtensions.cs
@@ -19,6 +19,11 @@ namespace Orleankka.TestKit
             return actor.OnReceive(message);
         }
 
+        public static async Task<object> Dispatch(this Actor actor, object message)
+        {
+            return await actor.Prototype.DispatchAsync(actor, message);
+        }
+
         public static Task OnReminder(this Actor actor, string id)
         {
             return actor.OnReminder(id);


### PR DESCRIPTION
I want to Unit test EventSourced actors which don't receive Events and thus cannot be tested via `OnRecieve` extention