### PR TITLE
Testkit: declarative stream matching validation 

### DIFF
--- a/Source/Orleankka.TestKit.Tests/Orleankka.TestKit.Tests.csproj
+++ b/Source/Orleankka.TestKit.Tests/Orleankka.TestKit.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ActorRefMockFixture.cs" />
     <Compile Include="ActorSystemMockFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StreamSubscriptionChecker.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orleankka.Core\Orleankka.Core.csproj">

--- a/Source/Orleankka.TestKit.Tests/StreamSubscriptionChecker.cs
+++ b/Source/Orleankka.TestKit.Tests/StreamSubscriptionChecker.cs
@@ -1,0 +1,49 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleankka.TestKit
+{
+
+    //[StreamSubscription(Source = "sms:/TEST-(.*)/", Target = "#")]
+    [StreamSubscription(Source = "sms:/TEST-(?<id>.*)/", Target = "{id}-test")]
+    public class Subscriber : Actor
+    {
+        public void Handler(int t)
+        {
+
+        }
+    }
+
+    [TestFixture]
+    public class StreamSubscriptionChecker
+    {
+        [Test]
+        public async Task Resturns_target_id_when_matched()
+        {
+            var recieves = await 
+                "sms:TEST-123".MatchesIdOf<Subscriber>(
+                                    "123-test",
+                                    "message");
+            Assert.That(recieves, Is.True);
+
+            /* alway fail
+            var ignoresInts = await "sms:TEST-123".MatchesIdOf<Subscriber>(
+                "123-test",
+                10);
+
+            Assert.That(ignoresInts, Is.False);
+            */
+
+            var ignoredDueToidMismatch = await "sms:TEST-123".MatchesIdOf<Subscriber>(
+                "222-test",
+                "message");
+            Assert.That(ignoredDueToidMismatch, Is.False);
+
+        }
+
+    }
+}

--- a/Source/Orleankka.TestKit.Tests/StreamSubscriptionChecker.cs
+++ b/Source/Orleankka.TestKit.Tests/StreamSubscriptionChecker.cs
@@ -29,7 +29,7 @@ namespace Orleankka.TestKit
         public async Task Returns_true_if_target_id_matches_specification(string stream, string target, bool result)
         {
             var recieves = await
-                           StreamSubscriptionValidator<Subscriber>.SubscribesToMessagesFrom
+                           StreamSubscriptionValidator<Subscriber>.AreMatched
                                 (stream, target);
             Assert.That(recieves, Is.EqualTo(result));
         }

--- a/Source/Orleankka.TestKit/Orleankka.TestKit.csproj
+++ b/Source/Orleankka.TestKit/Orleankka.TestKit.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ClientObserverStub.cs" />
     <Compile Include="ObserverCollectionMock.cs" />
     <Compile Include="ReminderServiceMock.cs" />
+    <Compile Include="StreamSubscriptionValidator.cs" />
     <Compile Include="TimerServiceMock.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Source/Orleankka.TestKit/StreamSubscriptionValidator.cs
+++ b/Source/Orleankka.TestKit/StreamSubscriptionValidator.cs
@@ -1,0 +1,41 @@
+﻿
+using Orleankka.Core.Streams;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Orleankka.TestKit
+{
+    public static class StreamSubscriptionValidator
+    {
+        public static async Task<bool> MatchesIdOf<T>(
+            this string fromStream,
+            string targetId,
+            object messageToRecieve) where T:Actor
+        {
+            Core.ActorType.Reset();
+            Core.ActorType.Register(new[] { typeof(T).Assembly });
+            var system = new ActorSystemMock();
+
+            var actorType = Core.ActorType.From(typeof(T));
+
+            var specs = StreamSubscriptionSpecification.From(actorType);
+            var spec = specs.ElementAt(0);
+            var match = spec.Match(system, fromStream);
+            if (match == StreamSubscriptionMatch.None)
+                return false;
+            //if (match.Filter(messageToRecieve))
+            //    return false;
+            var recievedBy = system.MockActorOf<T>(targetId);
+            await match.Receiver(messageToRecieve);
+
+            return recievedBy.RecordedMessages.Any();
+
+        }
+
+
+    }
+    
+}

--- a/Source/Orleankka.TestKit/StreamSubscriptionValidator.cs
+++ b/Source/Orleankka.TestKit/StreamSubscriptionValidator.cs
@@ -10,7 +10,7 @@ namespace Orleankka.TestKit
 {
     public static class StreamSubscriptionValidator<T> where T : Actor
     {
-        public static async Task<bool> SubscribesToMessagesFrom(
+        public static async Task<bool> AreMatched(
             string fromStream,
             string targetId)
         {


### PR DESCRIPTION
early preview.

todo, discuss: 

1. do we need check for message filtering (e.g. handler by handler)? If needed there could be more specific validation result: no match, matched but filtered.
1. make method sync
