### PR TITLE
replaced custom Result<> on Choice<> type which is more ideomatic.

### DIFF
--- a/Source/FSharp.Api/Task.fs
+++ b/Source/FSharp.Api/Task.fs
@@ -6,25 +6,11 @@ open System
 open System.Threading
 open System.Threading.Tasks
 
-/// Task result
-type Result<'T> = 
-   /// Task was canceled
-   | Canceled
-   /// Unhandled exception in task
-   | Error of exn
-   /// Task completed successfully
-   | Successful of 'T
-
 let run (t:unit -> Task<_>) = 
-   try     
-      t().Result |> Result.Successful
+   try
+     t().Result |> Choice1Of2
    with
-   | :? OperationCanceledException -> Result.Canceled
-   | :? AggregateException as e -> 
-      match e.InnerException with
-      | :? TaskCanceledException -> Result.Canceled
-      | _ -> Result.Error e
-   | e -> Result.Error e
+   | e -> Choice2Of2(e)
 
 let inline wait (task:Task<_>) = task.Wait()
 


### PR DESCRIPTION
Also I have found that many libraries use custom Result<_> type but they always provides functor like fromChoice

https://github.com/trustpilot/Trustpilot.FSharp.Flow/blob/master/src/Trustpilot.FSharp.Flow/Flow.fs#L21

